### PR TITLE
Change `selflearning-switch` service type from `Lightbulb` to `Switch`

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function(homebridge) {
 	const modelDefinitions = [
 		{
 			model: 'selflearning-switch',
-			definitions: [{ service: Service.Lightbulb, characteristics: [ Characteristic.On ] }],
+			definitions: [{ service: Service.Switch, characteristics: [ Characteristic.On ] }],
 		},
 		{
 			model: 'codeswitch',


### PR DESCRIPTION
Hi, 

This PR changes the service type of `selflearning-switch` from `Lightbulb` to `Switch`

Formerly when using switches of the type `selflearning-switch` they would show up in HomeKit only as lightbulbs, this is unfortunate as there are multiple Telldus compatible sockets and switches of this type that are not necessarily hooked up to lightbulbs. 

By changing the service to `Switch` it shows up in HomeKit as a switch, which can be configured to display and act like a lightbulb in HomeKit. 