### PR TITLE
Homekit automation sends "on" after dim event

### DIFF
--- a/index.js
+++ b/index.js
@@ -352,7 +352,7 @@ module.exports = function(homebridge) {
 
 							// Don't turn on if already on for dimmer (prevents problems when dimming)
 							// Because homekit sends both Brightness command and On command at the same time.
-							const isDimmer = characteristics.indexOf(Characteristic.Brightness) > -1;
+							const isDimmer = characteristics.indexOf(Characteristic.Brightness) > -1 || cdevice.statevalue !== '0';
 							if (powerOn && isDimmer && cx.getValueFromDev(cdevice)) return callback();
 
 							bluebird.resolve(api.onOffDevice(this.device.id, powerOn)).asCallback(err => {


### PR DESCRIPTION
When setting a light to be dimmed at a certain level in automation in Homekit, Homekit first sends dim event and then on event causing lights to be 100% dimmed no matter what specified in the automation task.